### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test releases
 
+permissions:
+  contents: read
+
 on: [push]
 
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/betwatch/betwatch-sdk-python/security/code-scanning/1](https://github.com/betwatch/betwatch-sdk-python/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for most CI workflows that do not require write access. This change ensures that the workflow adheres to the principle of least privilege and mitigates potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
