### PR TITLE
Add BetBunker to Bookmaker enum

### DIFF
--- a/betwatch/types/bookmakers.py
+++ b/betwatch/types/bookmakers.py
@@ -101,6 +101,7 @@ class Bookmaker(str, Enum):
     VINBET = "Vinbet"
     BETCHAMPS = "Betchamps"
     TRADIEBET = "Tradiebet"
+    BETBUNKER = "Betbunker"
     TABNZ = "Tab NZ"
     BETLEGENDS = "BetLegends"
     CROWNBET = "CrownBet"

--- a/tests/test_unknown_enum_values.py
+++ b/tests/test_unknown_enum_values.py
@@ -95,6 +95,7 @@ def test_case_insensitive_bookmaker():
         ("Next2Go", Bookmaker.NEXT2GO),
         ("PuntX", Bookmaker.PUNTX),
         ("TerryBet", Bookmaker.TERRYBET),
+        ("Betbunker", Bookmaker.BETBUNKER),
     ],
 )
 def test_new_bookmakers_are_known(raw_bookmaker, enum_bookmaker):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `BETBUNKER` to the Python SDK `Bookmaker` enum so BetBunker prices resolve as a known bookmaker.

## Changes

- Add `BETBUNKER = "Betbunker"` in `betwatch/types/bookmakers.py`, next to the other PuntersTech books (`STARSPORTS`, `VINBET`, `BETCHAMPS`, `TRADIEBET`).
- The string value is `Betbunker` (one word, capital B) to match the website enum and cobra `COMPANY_MAPPING` name.
- Include BetBunker in `test_new_bookmakers_are_known` so the new member resolves to the enum.

Version is unchanged; this repo does not require a bump for a bookmaker add.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0f342b0-6676-4377-9352-8e7d33be45ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0f342b0-6676-4377-9352-8e7d33be45ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

